### PR TITLE
Update aptos-coinlist.json

### DIFF
--- a/aptos-coinlist.json
+++ b/aptos-coinlist.json
@@ -540,6 +540,18 @@
       "tags": [],
       "extensions": {
         "coingeckoId": "bluemove"
+      },
+          },
+    {
+      "chainId": 1,
+      "address": "0xc71d94c49826b7d81d740d5bfb80b001a356198ed7b8005ae24ccedff82b299c::bridge::APTS",
+      "symbol": "APTS",
+      "name": "apts coin",
+      "logoURI": "https://aptos-mainnet-api.bluemove.net/uploads/apts_logo_e01c69dffb.svg",
+      "decimals": 8,
+      "tags": [],
+      "extensions": {
+        "coingeckoId": ""
       }
     }
   ]


### PR DESCRIPTION
Hi Solflare Team,

The BlueMove team is excited to request the addition of the APTS coin to Aptos-coin-list on GitHub. Recently, BlueMove successfully launched the $APTS inscription token, following the DA standard, and it has been warmly welcomed by the community.

In our efforts to enhance the utility of the $APTS token, we've also developed a bridge that allows seamless conversion between the $APTS inscription token and $APTS coin. For further details, please refer to our announcement here:
https://twitter.com/BlueMove_OA/status/1736656999621009858

We greatly appreciate your team's efforts and would love to receive your feedback soon.

Thanks and best regards